### PR TITLE
Add an option to overwrite/skip .png files that already exist in the target directory

### DIFF
--- a/photoshopCompositionComposer-v0.1.jsx
+++ b/photoshopCompositionComposer-v0.1.jsx
@@ -117,12 +117,15 @@ function combine() {
         if (!overwritePreExistingPngFlag) {
         var fileHandle = File(fileFullPath + '.png');
           if (fileHandle.exists) {
-            // Skip iteration as the file already exists (to save time)
-            continue;
+            // Do nothing as the file already exists (to save time)
+          } else {
+              saveDocumentAsPNG(fileFullPath);
           }
+        } else {
+            // Just save the file regardless of if it exists as we are always overwriting
+           saveDocumentAsPNG(fileFullPath); 
         }
 
-        saveDocumentAsPNG(fileFullPath);
         if(includePSDFiles) saveDocumentAsPSD(fileFullPath);
       }
 }

--- a/photoshopCompositionComposer-v0.1.jsx
+++ b/photoshopCompositionComposer-v0.1.jsx
@@ -97,7 +97,10 @@ function combine() {
 
       var includePSDFiles = confirm('Would you like to include corresponding PSD documents?')
 
+      var overwritePreExistingPngFlag = confirm('Would you like to overwrite pre-existing PNG files?')
+
       for(var i = 0; i < artLayerCollectionCollectionCombinations.length; i++) {
+
         hideAllArtLayers();
         var artLayerNames = [];
         for(var z = 0; z < artLayerCollectionCollectionCombinations[i].length; z++) {
@@ -106,8 +109,21 @@ function combine() {
           artLayerNames.push(artLayer.parent.name);
           artLayerNames.push(artLayer.name);
         }
-        saveDocumentAsPNG(savePath + '/' + normalizeSaveFileName(artLayerNames.join('')).substr(0, 254));
-        if(includePSDFiles) saveDocumentAsPSD(savePath + '/' + normalizeSaveFileName(artLayer.parent.name + artLayerNames.join('')).substr(0, 254));
+
+        var fileFullPath = savePath + '/' + normalizeSaveFileName(artLayerNames.join('')).substr(0, 254);
+
+        // If this is false then we need to check before writing a file so we
+        // can skip pre-existing files
+        if (!overwritePreExistingPngFlag) {
+        var fileHandle = File(fileFullPath + '.png');
+          if (fileHandle.exists) {
+            // Skip iteration as the file already exists (to save time)
+            continue;
+          }
+        }
+
+        saveDocumentAsPNG(fileFullPath);
+        if(includePSDFiles) saveDocumentAsPSD(fileFullPath);
       }
 }
 


### PR DESCRIPTION
Hi

I am using this script to generate some images but was having issues where I was generating tens of thousands of permutations. Occasionally Photoshop would get interrupted and I had to start all over again.

To resolve this I have added an extra prompt to ask if the user wants to overwrite pre-existing .png files. If they opt not to overwrite them, then there is a check before a .png file is written, and if the file already exists then the script continues directly to the next combination without saving.

This is totally independent of .psd image generation.
